### PR TITLE
Fix the default credential logic

### DIFF
--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -64,6 +64,12 @@ func defaultCredentials() []config.CredentialConfig {
 	clientID := envy.Get("AZURE_CLIENT_ID", "")
 	clientSecret := envy.Get("AZURE_CLIENT_SECRET", "")
 
+	// If none of the values were passed, return an empty slice
+	if tenantID == "" && clientID == "" && clientSecret == "" {
+		return make([]config.CredentialConfig, 0)
+	}
+
+	// Otherwise return a slice of n=1 credential
 	return []config.CredentialConfig{config.CredentialConfig{
 		Name:         "default",
 		TenantID:     tenantID,

--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -24,7 +24,7 @@ type Config struct {
 }
 
 func ParseConfig(path string) Config {
-	config := Config{Credentials: defaultCredentials()}
+	config := Config{}
 	data, err := ioutil.ReadFile(path)
 
 	if err != nil {
@@ -71,24 +71,23 @@ func defaultCredentials() []config.CredentialConfig {
 		ClientSecret: clientSecret}}
 }
 
+// Since a is not a pointer, a is a *copy* of the object being passed
 func mergeCredentials(a []config.CredentialConfig, b []config.CredentialConfig) []config.CredentialConfig {
-	merged := a
-
 	var found bool
 	for i, addition := range b {
 		found = false
-		for j, base := range merged {
+		for j, base := range a {
 			if base.Name == addition.Name {
 				found = true
-				merged[j] = b[i]
+				a[j] = b[i]
 			}
 		}
 		if !found {
-			merged = append(merged, addition)
+			a = append(a, addition)
 		}
 	}
 
-	return merged
+	return a
 }
 
 func validateCredentialConfigs(credentialConfigs []config.CredentialConfig) {

--- a/configparser/configparser.go
+++ b/configparser/configparser.go
@@ -36,6 +36,8 @@ func ParseConfig(path string) Config {
 		panic(fmt.Sprintf("Error unmarshalling yaml: %v", err))
 	}
 
+	config.Credentials = mergeCredentials(defaultCredentials(), config.Credentials)
+
 	validateCredentialConfigs(config.Credentials)
 
 	parseWorkerConfigs(config)
@@ -67,6 +69,26 @@ func defaultCredentials() []config.CredentialConfig {
 		TenantID:     tenantID,
 		ClientID:     clientID,
 		ClientSecret: clientSecret}}
+}
+
+func mergeCredentials(a []config.CredentialConfig, b []config.CredentialConfig) []config.CredentialConfig {
+	merged := a
+
+	var found bool
+	for i, addition := range b {
+		found = false
+		for j, base := range merged {
+			if base.Name == addition.Name {
+				found = true
+				merged[j] = b[i]
+			}
+		}
+		if !found {
+			merged = append(merged, addition)
+		}
+	}
+
+	return merged
 }
 
 func validateCredentialConfigs(credentialConfigs []config.CredentialConfig) {


### PR DESCRIPTION
Fix the default credential logic so that it will merge the values from .env in with any list supplied via yaml

The logic is now:

* Load any values from environment variables into `default` credential
* Overwrite the `default` credential if the yaml file has one, otherwise leave it alone
* Pass the merged list to the resources to be consumed


I tested the following scenarios (the resources did not specify any credential and thus relied on the default fallback credential logic):
* No credentials list, no .env file, the error is "no credential default found"
* Credentials list with only `test`, no .env file, the error is "no credential default found"
* Credentials list with `test` and `default`, it discovers the default credentials and works
* Credentials list with `test`, and a .env file, it discovers the default credentials and works