### PR TITLE
Cert helper refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ When you create a Cert in azure key vault, it automatically creates a Secret and
 
 To fetch the private key, you'll need to ensure that the Secret is in your resources section. You will also need to use the built-in `privateKey` and `cert` helpers to parse the blob into its respective pieces.
 
-Note: `cert` will only return the leaf certificate
+Note: `cert` helper will only return the leaf certificate
 
 In the example below, it is assumed you have created a PEM format certificate with the name `pem-test`:
 
@@ -109,12 +109,12 @@ workers:
     postChange: service nginx restart
     sinks:
       - path: ./pem-test.key
-        template: '{{ privateKey "pem-test" }}'
+        template: '{{ index .Secrets "pem-test" | privateKey }}'
         owner: myuser
         group: mygroup
         mode: 0600
       - path: ./pem-test.cert
-        template: '{{ cert "pem-test" }}'
+        template: '{{ index .Secrets "pem-test" | cert }}'
 ```
 
 Complete List of Cert Helpers:
@@ -127,9 +127,10 @@ Complete List of Cert Helpers:
 
 `fullChain` - returns full certificate chain including leaf cert in PEM format.
 
-Note: The `issuers` and `fullChain` helpers will do their best to reconstruct the chain, but can only work with the data
+Note: 
+- The resource type `cert` does not contain any chain information due to the way Azure stores the data.  If you wish to use `issuers` or `fullChain` helpers, you must do so on a `secret` resource.  An empty string will be returned if you try to run either on a `cert` resource.
+- The `issuers` and `fullChain` helpers will do their best to reconstruct the chain, but can only work with the data
 given.  So if you did not store your certificate with its chain an empty string will be returned.
-
 ### Multiple secrets in a file
 
 Let's suppose you had 4 secrets in a given key vault, `dbHost`, `dbName`, `dbUser`, `dbPass`.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Complete List of Cert Helpers:
 `fullChain` - returns full certificate chain including leaf cert in PEM format.
 
 Note: 
-- The resource type `cert` does not contain any chain information due to the way Azure stores the data.  If you wish to use `issuers` or `fullChain` helpers, you must do so on a `secret` resource.  An empty string will be returned if you try to run either on a `cert` resource.
+- The resource type `cert` does not contain any chain information due to the way Azure stores the data.  If you wish to use `issuers` or `fullChain` helpers, you must do so on a `secret` resource.
 - The `issuers` and `fullChain` helpers will do their best to reconstruct the chain, but can only work with the data
 given.  So if you did not store your certificate with its chain an empty string will be returned.
 ### Multiple secrets in a file

--- a/certutil/certutil.go
+++ b/certutil/certutil.go
@@ -97,6 +97,21 @@ func PemCertFromPem(data string) string {
 	return certPem.String()
 }
 
+func PemCertFromBytes(derBytes []byte) string {
+	leaf, err := x509.ParseCertificate(derBytes)
+	if err != nil {
+		panic(err)
+	}
+
+	// Encode just the leaf cert as pem
+	var certPem bytes.Buffer
+	if err := pem.Encode(&certPem, &pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw}); err != nil {
+		panic(fmt.Sprintf("Failed to write data: %s", err))
+	}
+
+	return certPem.String()
+}
+
 func PemChainFromPkcs12(b64pkcs12 string, justIssuers bool) string {
 	p12, _ := base64.StdEncoding.DecodeString(b64pkcs12)
 

--- a/certutil/certutil.go
+++ b/certutil/certutil.go
@@ -138,6 +138,20 @@ func PemChainFromPem(data string, justIssuers bool) string {
 	return SortedChain(certAndKey.Certificate, justIssuers)
 }
 
+func PemChainFromBytes(derBytes []byte, justIssuers bool) string {
+	certs, err := x509.ParseCertificates(derBytes)
+	if err != nil {
+		panic(fmt.Sprintf("Error parsing Certificate: %v", err))
+	}
+
+	var rawCerts [][]byte
+	for _, c := range certs {
+		rawCerts = append(rawCerts, c.Raw)
+	}
+
+	return SortedChain(rawCerts, justIssuers)
+}
+
 func SortedChain(rawChain [][]byte, justIssuers bool) string {
 	g := graph.New(graph.Directed)
 

--- a/certutil/certutil.go
+++ b/certutil/certutil.go
@@ -138,20 +138,6 @@ func PemChainFromPem(data string, justIssuers bool) string {
 	return SortedChain(certAndKey.Certificate, justIssuers)
 }
 
-func PemChainFromBytes(derBytes []byte, justIssuers bool) string {
-	certs, err := x509.ParseCertificates(derBytes)
-	if err != nil {
-		panic(fmt.Sprintf("Error parsing Certificate: %v", err))
-	}
-
-	var rawCerts [][]byte
-	for _, c := range certs {
-		rawCerts = append(rawCerts, c.Raw)
-	}
-
-	return SortedChain(rawCerts, justIssuers)
-}
-
 func SortedChain(rawChain [][]byte, justIssuers bool) string {
 	g := graph.New(graph.Directed)
 

--- a/certutil/certutil.go
+++ b/certutil/certutil.go
@@ -98,14 +98,9 @@ func PemCertFromPem(data string) string {
 }
 
 func PemCertFromBytes(derBytes []byte) string {
-	leaf, err := x509.ParseCertificate(derBytes)
-	if err != nil {
-		panic(err)
-	}
-
 	// Encode just the leaf cert as pem
 	var certPem bytes.Buffer
-	if err := pem.Encode(&certPem, &pem.Block{Type: "CERTIFICATE", Bytes: leaf.Raw}); err != nil {
+	if err := pem.Encode(&certPem, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); err != nil {
 		panic(fmt.Sprintf("Failed to write data: %s", err))
 	}
 

--- a/templaterenderer/templaterenderer.go
+++ b/templaterenderer/templaterenderer.go
@@ -77,7 +77,7 @@ func RenderInline(templateContents string, resourceMap resource.ResourceMap) str
 	var buf bytes.Buffer
 	err = t.Execute(&buf, resourceMap)
 	if err != nil {
-		panic(fmt.Sprintf("Error executing template:\n%v\nResources:\n%v\nError:\n%v\n", templateContents, resourceMap, err))
+		panic(fmt.Sprintf("Error executing template: %v Error: %v", templateContents, err))
 	}
 
 	result := buf.String()

--- a/templaterenderer/templaterenderer.go
+++ b/templaterenderer/templaterenderer.go
@@ -45,8 +45,8 @@ func RenderInline(templateContents string, resourceMap resource.ResourceMap) str
 		"cert": func(resource resource.Resource) string {
 			switch t := resource.(type) {
 			case certs.Cert:
-				log.Print("Got a Cert")
-				return certFromCert(resource.(certs.Cert))
+				cert := resource.(certs.Cert)
+				return certutil.PemCertFromBytes(*cert.Cer)
 			case secrets.Secret:
 				log.Print("Got a Secret")
 				return certFromSecret(resource.(secrets.Secret))
@@ -106,15 +106,6 @@ func RenderInline(templateContents string, resourceMap resource.ResourceMap) str
 	result := buf.String()
 
 	return result
-}
-
-func certFromCert(cert certs.Cert) string {
-	switch contentType := *cert.ContentType; contentType {
-	case "application/x-pem-file":
-		return certutil.PemCertFromBytes(*cert.Cer)
-	default:
-		panic(fmt.Sprintf("Got unexpected content type: %v", contentType))
-	}
 }
 
 func certFromSecret(secret secrets.Secret) string {


### PR DESCRIPTION
This change will make interaction with helper functions consistent.  Previously the cert helper functions were passed a name which they used to lookup objects in our Secrets map.  Now the cert helper functions are fed a proper resource object and helpers are executed when possible.

The following cert helpers work with the following types

Type: Cert, Helpers: cert 
Type: Secret, Helpers: cert, issuers, fullChain, privateKey
Type: Key, Helpers: none