### PR TITLE
add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:alpine as builder
+WORKDIR /go/src/app
+COPY . .
+RUN CGO_ENABLED=0 go install -ldflags '-extldflags "-static"'
+
+FROM scratch
+COPY --from=builder /go/bin/azure-key-vault-agent /azure-key-vault-agent
+ENTRYPOINT ["/azure-key-vault-agent"]
+CMD ["-config", "/akva.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM golang:alpine as builder
-WORKDIR /go/src/app
-COPY . .
-RUN CGO_ENABLED=0 go install -ldflags '-extldflags "-static"'
-
-FROM scratch
-COPY --from=builder /go/bin/azure-key-vault-agent /azure-key-vault-agent
-ENTRYPOINT ["/azure-key-vault-agent"]
-CMD ["-config", "/akva.yaml"]
+FROM alpine
+RUN apk add --no-cache libc6-compat
+ADD https://github.com/covermymeds/azure-key-vault-agent/releases/download/v1.4.0/azure-key-vault-agent_1.4.0_linux_amd64.tar.gz /opt/akva/
+RUN tar -xvf /opt/akva/azure-key-vault-agent_1.4.0_linux_amd64.tar.gz -C /opt/akva/
+CMD ["/opt/akva/azure-key-vault-agent", "-config", "/opt/akva/akva.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
+FROM golang:alpine as builder
+WORKDIR /go/src/app
+COPY . .
+RUN CGO_ENABLED=0 go install -ldflags '-extldflags "-static"'
+
 FROM alpine
-RUN apk add --no-cache libc6-compat
-ADD https://github.com/covermymeds/azure-key-vault-agent/releases/download/v1.4.0/azure-key-vault-agent_1.4.0_linux_amd64.tar.gz /opt/akva/
-RUN tar -xvf /opt/akva/azure-key-vault-agent_1.4.0_linux_amd64.tar.gz -C /opt/akva/
-CMD ["/opt/akva/azure-key-vault-agent", "-config", "/opt/akva/akva.yaml"]
+COPY --from=builder /go/bin/azure-key-vault-agent /azure-key-vault-agent
+CMD ["/azure-key-vault-agent", "-config", "/akva.yaml"]


### PR DESCRIPTION
This add a simple Dockerfile to build a container from the current (1.4.0) release of the binary.  It uses an `alpine` base image, and stores the application at `/azure-key-vault-agent`.  The default command is `/azure-key-vault-agent -c /akva.yaml`.

`docker build -t akva:dev .` to build the container and tag it `akva:dev`.

You can test that this works with a simple docker-compose.yml:
```
---
version: "3.3"
services:
    akva:
        image: akva:dev
        volumes:
            - secrets:/etc/secrets
            - ./opt/akva/akva.yaml:/akva.yaml
    app:
        image: alpine
        command: "sleep 300"
        volumes:
            - secrets:/etc/secrets
volumes:
    secrets:
```

```
$ docker-compose up -d
Creating network "akva_default" with the default driver
Creating akva_akva_1 ... done
Creating akva_app_1  ... done
$ docker-compose exec app /bin/sh
/ # ls /etc/secrets/
kv-test
```

You can move your Azure credentials to a different file and make the environment variables:
```
---
version: "3.3"
services:
    akva:
        image: akva:dev
        env_file:
            - ./akva.env
        volumes:
            - secrets:/etc/secrets
            - ./akva.yaml:/akva.yaml
    app:
        image: alpine
        command: "sleep 300"
        volumes:
            - secrets:/etc/secrets
volumes:
    secrets:
```

*Note*: a previous iteration of this PR tried using a `Scratch` base image to run just the binary with no filesystem and no other tooling.  That did not seem to work.  The container size of the scatch-based image was 13MB; and the size with Alpine is 20MB.  That's a very small price to pay for a little more convenience (and something that actually works!).