### PR TITLE
Add functionality to run once and exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ workers:
 
 # Workers
 
-Workers work in a loop, whose frequency is controlled by the `frequency` field in your config. Each iteration of the loop, the worker performs the following:
+Workers default to working in a loop, whose frequency is controlled by the `frequency` field in your config. Each iteration of the loop, the worker performs the following:
 
 * Fetch all of the specified resources
 * If any errors occur, fail the iteration and:
@@ -286,6 +286,8 @@ Workers work in a loop, whose frequency is controlled by the `frequency` field i
   * Load and/or parse the specified template, and render it using the fetched resources
   * Compare the results of the template to the contents of the destination path
   * If the contents differ, trigger any `preChange` hook, write the contents to the `path`, and trigger any `postChange` hook
+
+If you want to run your workers once and then exit, pass the `--once` option to the executable.
 
 # Config watcher
 

--- a/configwatcher/configwatcher.go
+++ b/configwatcher/configwatcher.go
@@ -36,6 +36,26 @@ func Watcher(path string) {
 	<-done // Block until done
 }
 
+func ParseAndRunWorkersOnce(path string) {
+	// Parse config file
+	config := configparser.ParseConfig(path)
+
+	// Initialize clients
+	clients := make(client.Clients)
+	for _, credentialConfig := range config.Credentials {
+		clients[credentialConfig.Name] = client.NewClient(credentialConfig)
+	}
+
+	// Start workers
+	log.Printf("Running workers once")
+	for _, workerConfig := range config.Workers {
+		err := worker.Process(nil, clients, workerConfig)
+		if err != nil {
+			log.Fatalf("Failed to get resource(s): %v", err)
+		}
+	}
+}
+
 func parseAndStartWorkers(path string) context.CancelFunc {
 	// Create background context for workers
 	ctx, cancel := context.WithCancel(context.Background())

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"github.com/covermymeds/azure-key-vault-agent/configwatcher"
+	"github.com/covermymeds/azure-key-vault-agent/worker"
 	"github.com/luci/luci-go/common/flag/flagenum"
 	log "github.com/sirupsen/logrus"
 	"os"
@@ -40,6 +41,7 @@ var output outputType
 var help bool
 var debugMode bool
 var ver bool
+var runOnce bool
 
 func init() {
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
@@ -51,6 +53,7 @@ func init() {
 	fs.StringVar(&configFile, "c", "", "Read config from this `file` (shorthand)")
 	fs.Var(&output, "output", fmt.Sprintf("Output type (default json). Options are: %v (default json)", outputTypeEnum.Choices()))
 	fs.BoolVar(&ver, "version", false, "Show the version of akva-key-vault-agent")
+	fs.BoolVar(&runOnce, "once", false, "Run once and quit")
 
 	fs.Parse(os.Args[1:])
 
@@ -94,5 +97,9 @@ func main() {
 		}
 	}()
 
-	configwatcher.Watcher(configFile)
+	if runOnce {
+		worker.WorkerOnce(configFile)
+	} else {
+		configwatcher.Watcher(configFile)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"github.com/covermymeds/azure-key-vault-agent/configwatcher"
-	"github.com/covermymeds/azure-key-vault-agent/worker"
 	"github.com/luci/luci-go/common/flag/flagenum"
 	log "github.com/sirupsen/logrus"
 	"os"
@@ -98,7 +97,7 @@ func main() {
 	}()
 
 	if runOnce {
-		worker.WorkerOnce(configFile)
+		configwatcher.ParseAndRunWorkersOnce(configFile)
 	} else {
 		configwatcher.Watcher(configFile)
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -13,7 +13,6 @@ import (
 	"github.com/covermymeds/azure-key-vault-agent/certs"
 	"github.com/covermymeds/azure-key-vault-agent/client"
 	"github.com/covermymeds/azure-key-vault-agent/config"
-	"github.com/covermymeds/azure-key-vault-agent/configparser"
 	"github.com/covermymeds/azure-key-vault-agent/keys"
 	"github.com/covermymeds/azure-key-vault-agent/resource"
 	"github.com/covermymeds/azure-key-vault-agent/secrets"
@@ -23,26 +22,6 @@ import (
 )
 
 const RetryBreakPoint = 60
-
-func WorkerOnce(path string) {
-	// Parse config file
-	config := configparser.ParseConfig(path)
-
-	// Initialize clients
-	clients := make(client.Clients)
-	for _, credentialConfig := range config.Credentials {
-		clients[credentialConfig.Name] = client.NewClient(credentialConfig)
-	}
-
-	// Start workers
-	log.Printf("Running workers once")
-	for _, workerConfig := range config.Workers {
-		err := Process(nil, clients, workerConfig)
-		if err != nil {
-			log.Printf("Failed to get resource(s): %v", err)
-		}
-	}
-}
 
 func Worker(ctx context.Context, clients client.Clients, workerConfig config.WorkerConfig) {
 	defer func() {


### PR DESCRIPTION
Very basic implementation. I opted to just create a `WorkerOnce` since adding new functions in `configwatcher` did not make sense, conceptually. The downside to this is that `main.go` needed to import `worker` and `worker` needed to import `configparser` to get the functionality in place.

Closes #50