### PR TITLE
Add aliases for resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,23 @@ Unless a resource has a `kind` of `all-secrets`, there is also a required `name`
 If you don't specify `credential`, a credential with the name `default` will be used (you can either
 specify the `default` credential in the `credentials` array, or as ENV vars / .env file)
 
+### Aliases
+
+A resource with a kind set to `cert`, `secret`, or `key` may specify an alias. This alias may be used to reference the resource in your specified `sink`:
+
+```yaml
+workers:
+  -
+    resources:
+      - kind: secret
+        name: my-application-password
+        alias: pass
+        vaultBaseURL: https://test-kv.vault.azure.net/
+    sinks:
+      - path: ./password
+        template: "{{ .Secrets.pass.Value }}"
+```
+
 ## Sinks
 
 The `sinks` section is a list of one or more files to write to. Each sink has a `path` and either `template` (inline template) or `templatePath` (path to template on the filesystem). The template syntax is golang's [text/template](https://golang.org/pkg/text/template/#hdr-Text_and_spaces) library (with [sprig](https://github.com/Masterminds/sprig) helpers).

--- a/config/resource.go
+++ b/config/resource.go
@@ -10,9 +10,10 @@ const (
 )
 
 type ResourceConfig struct {
-	Kind         ResourceKind `yaml:"kind,omitempty" validate:"required,oneof=cert key secret all-secrets"`
-	VaultBaseURL string       `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
-	Name         string       `yaml:"name"`
+	Alias        string       `yaml:"alias,omitempty"`
 	Credential   string       `yaml:"credential,omitempty"`
+	Kind         ResourceKind `yaml:"kind,omitempty" validate:"required,oneof=cert key secret all-secrets"`
+	Name         string       `yaml:"name"`
+	VaultBaseURL string       `yaml:"vaultBaseURL,omitempty" validate:"required,url"`
 	Version      string       `yaml:"version,omitempty"`
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -90,6 +90,9 @@ func Process(ctx context.Context, clients client.Clients, workerConfig config.Wo
 				return err
 			}
 			resources.Certs[resourceConfig.Name] = result
+			if resourceConfig.Alias != "" {
+				resources.Certs[resourceConfig.Alias] = result
+			}
 
 		case config.SecretKind:
 			result, err := secrets.GetSecret(client, resourceConfig.VaultBaseURL, resourceConfig.Name, resourceConfig.Version)
@@ -97,6 +100,9 @@ func Process(ctx context.Context, clients client.Clients, workerConfig config.Wo
 				return err
 			}
 			resources.Secrets[resourceConfig.Name] = result
+			if resourceConfig.Alias != "" {
+				resources.Secrets[resourceConfig.Alias] = result
+			}
 
 		case config.AllSecretsKind:
 			result, err := secrets.GetSecrets(client, resourceConfig.VaultBaseURL)
@@ -111,6 +117,9 @@ func Process(ctx context.Context, clients client.Clients, workerConfig config.Wo
 				return err
 			}
 			resources.Keys[resourceConfig.Name] = result
+			if resourceConfig.Alias != "" {
+				resources.Keys[resourceConfig.Alias] = result
+			}
 
 		default:
 			panic(fmt.Sprintf("Invalid sink kind: %v", resourceConfig.Kind))


### PR DESCRIPTION
This adds aliases for `cert`, `key`, and `secret` resources. If an alias is specified, it is added to the appropriate map with the same value as the resource's name

Tested with the following config:
```yaml
workers:
  -
    resources:
      - kind: secret
        name: secret-key-base
        alias: skb
        vaultBaseURL: https://vault-tst.vault.azure.net/
        credential: request-keys

    sinks:
      - path: secrets.json
        template: "{{ index .Secrets.skb.Value }}"
    frequency: 60s
```

Closes #56