### PR TITLE
Handle nil/unset ContentType in expandFullChain helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# [v1.7.1] - 2023-05-30
+
+### New bugfix release
+
+- Fixes bug in template helper `expandFullChain` introduced in https://github.com/covermymeds/azure-key-vault-agent/pull/86 where `expandFullChain` would throw a fatal error if secrets did not have a ContentType set
+
+
 # [v1.7.0] - 2023-05-19
 
 ### New minor release

--- a/templaterenderer/templaterenderer.go
+++ b/templaterenderer/templaterenderer.go
@@ -61,15 +61,17 @@ func RenderInline(templateContents string, resourceMap resource.ResourceMap) str
 
 			for secretName, secret := range items {
 				results[secretName] = secret
-				switch contentType := *secret.ContentType; contentType {
-				case "application/x-pem-file":
-					results[secretName+".key"] = cloneSecret(secret, certutil.PemPrivateKeyFromPem(*secret.Value))
-					results[secretName+".pem"] = cloneSecret(secret, certutil.PemChainFromPem(*secret.Value, false))
-				case "application/x-pkcs12":
-					results[secretName+".key"] = cloneSecret(secret, certutil.PemPrivateKeyFromPkcs12(*secret.Value))
-					results[secretName+".pem"] = cloneSecret(secret, certutil.PemChainFromPkcs12(*secret.Value, false))
-				default:
-					continue
+				if secret.ContentType != nil {
+					switch contentType := *secret.ContentType; contentType {
+					case "application/x-pem-file":
+						results[secretName+".key"] = cloneSecret(secret, certutil.PemPrivateKeyFromPem(*secret.Value))
+						results[secretName+".pem"] = cloneSecret(secret, certutil.PemChainFromPem(*secret.Value, false))
+					case "application/x-pkcs12":
+						results[secretName+".key"] = cloneSecret(secret, certutil.PemPrivateKeyFromPkcs12(*secret.Value))
+						results[secretName+".pem"] = cloneSecret(secret, certutil.PemChainFromPkcs12(*secret.Value, false))
+					default:
+						continue
+					}
 				}
 			}
 			return results


### PR DESCRIPTION
# Summary

In https://github.com/covermymeds/azure-key-vault-agent/pull/86, the `expandFullChain` template helper was added, but it didn't account for secrets that do not have a ContentType.  This bugfix will allow secrets without a ContentType to be used with the `expandFullChain` template helper.

## Testing
I tested that the `expandFullChain` template helper renders secrets as expected with the following:

- [x] A keyvault with a mixture of string secrets + certificates, where one secret has a contentType and another secret does not have a contentType
- [x] A keyvault with just certificates
- [x] A keyvault with just string secrets, where one secret has a contentType and another secret does not have a contentType
- [x] A keyvault with just string secrets, where all secrets have a contentType
- [x] A keyvault with just string secrets, where no secrets have a contentType


```# Example akva.yaml

workers:
  -
    resources:
      - kind: all-secrets
        vaultBaseURL: https://my-testing-keyvault.vault.azure.net/
        credential: my-testing-keyvault
    sinks:
      - path: secrets.json
        template: "{{ index .Secrets | expandFullChain | toValues | toJson }}"
      - path: testing.pem
        template: '{{ index .Secrets "testing" | fullChain }}'
      - path: testing.key
        template: '{{ index .Secrets "testing" | privateKey }}'
      - path: testingwithcontenttype.txt
        template: "{{ .Secrets.testingwithcontenttype.Value }}"
      - path: testingnocontenttype.txt
        template: "{{ .Secrets.testingnocontenttype.Value }}"
    frequency: 10s

# Run AKVA with `go mod download && go build . && ./azure-key-vault-agent -c ./akva.yaml`

# secrets.json - returns all original secrets, plus pem and key separated out for any certificates and renders secrets without a content type correctly:

{"testing":"...","testing.key":"...","testing.pem":"...","testingwithcontenttype":"...","testingnocontenttype":"..."}