### PR TITLE
Fix goreleaser actions

### DIFF
--- a/.github/workflows/prbuild.yml
+++ b/.github/workflows/prbuild.yml
@@ -22,7 +22,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
-          version: latest
-          args: release --skip-publish
+          version: '~>v2'
+          args: release --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagrelease.yml
+++ b/.github/workflows/tagrelease.yml
@@ -22,9 +22,9 @@ jobs:
           go-version: 1.17.x
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v3
         with:
-          version: latest
+          version: '~>v2'
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagrelease.yml
+++ b/.github/workflows/tagrelease.yml
@@ -25,7 +25,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v1
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/covermymeds/azure-key-vault-agent
 
-go 1.22.7
-
-toolchain go1.23.4
+go 1.23
 
 require (
 	github.com/Azure/azure-sdk-for-go v37.1.0+incompatible


### PR DESCRIPTION
Release of previous PR failed, seemingly related to use of `latest` version of the goreleaser. This fixes errors and pins the version to avoid this in the future.